### PR TITLE
refactor(client): overhaul

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
     "Lua.diagnostics.globals": [
         "QBX",
-        "DrawText3D"
+        "DrawText3D",
+        "lib",
+        "cache"
     ]
 }

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,18 +1,14 @@
 local config = require 'config.client'
-local policeAlert = 0
 local guardsDead = false
 local truckBlip
-local transport
+local truck
 local missionStarted = false
-local vehicleCoords = nil
-local dealer
-local pilot = nil
-local navigator = nil
+local dealer, pilot, navigator
 
 AddEventHandler('onResourceStart', function(resource)
 	if resource ~= GetCurrentResourceName() then return end
 	lib.requestModel(config.dealerModel)
-	dealer = CreatePed(26, config.dealerModel, config.dealerModelCoords.x, config.dealerModelCoords.y, config.dealerModelCoords.z, 268.9422, false, false)
+	dealer = CreatePed(26, config.dealerModel, config.dealerCoords.x, config.dealerCoords.y, config.dealerCoords.z, 268.9422, false, false)
 	SetEntityHeading(dealer, 1.8)
 	SetBlockingOfNonTemporaryEvents(dealer, true)
 	TaskStartScenarioInPlace(dealer, 'WORLD_HUMAN_AA_SMOKE', 0, false)
@@ -21,9 +17,11 @@ AddEventHandler('onResourceStart', function(resource)
 		name = 'dealer',
 		label = Lang:t('mission.accept_mission_target'),
 		icon = 'fas fa-circle-check',
-		serverEvent = 'truckrobbery:AcceptMission',
 		canInteract = function()
 			return not missionStarted and QBX.PlayerData.job.type ~= 'leo'
+		end,
+		onSelect = function()
+			lib.callback('qbx_truckrobbery:server:startMission')
 		end,
 		distance = 3.0,
 	})
@@ -36,15 +34,11 @@ AddEventHandler('onResourceStop', function(resource)
 end)
 
 local function callCops()
-    if policeAlert == 0 then
-        local transCoords = GetEntityCoords(transport)
-        TriggerServerEvent('truckrobbery:server:callCops', transCoords)
-        PlaySoundFrontend(-1, 'Mission_Pass_Notify', 'DLC_HEISTS_GENERAL_FRONTEND_SOUNDS', false)
-        policeAlert = 1
-    end
+	lib.callback('qbx_truckrobbery:server:callCops', false, nil, GetEntityCoords(truck))
+	PlaySoundFrontend(-1, 'Mission_Pass_Notify', 'DLC_HEISTS_GENERAL_FRONTEND_SOUNDS', false)
 end
 
-RegisterNetEvent('truckrobbery:client:robberyCall', function(msg, coords)
+lib.callback.register('qbx_truckrobbery:client:notifyCop', function(msg, coords)
     PlaySound(-1, 'Lose_1st', 'GTAO_FM_Events_Soundset', false, 0, true)
     exports.qbx_core:Notify(msg, 'police', 10000)
 
@@ -71,171 +65,16 @@ RegisterNetEvent('truckrobbery:client:robberyCall', function(msg, coords)
     end
 end)
 
-function MissionNotification()
-	Wait(2000)
-	config.emailNotification()
-	Wait(3000)
-end
-
-local function createBombPlantingTarget()
-	exports.ox_target:addLocalEntity(transport, {
-		name = 'transportPlant',
-		label = Lang:t('info.plant_bomb'),
-		icon = 'fas fa-bomb',
-		canInteract = function()
-			return QBX.PlayerData.job.type ~= 'leo'
-		end,
-		onSelect = PlantBomb,
-		distance = 3.0,
-	})
-end
-
-RegisterNetEvent('truckrobbery:StartMission', function()
-	MissionNotification()
-	ClearPedTasks(dealer)
-	TaskWanderStandard(dealer, 10.0, 10)
-	local drawCoord = math.random(1, #config.truckSpawns)
-	vehicleCoords = config.truckSpawns[drawCoord]
-
-	lib.requestModel(joaat(config.truckModel))
-
-	ClearAreaOfVehicles(vehicleCoords.x, vehicleCoords.y, vehicleCoords.z, 15.0, false, false, false, false, false)
-	transport = CreateVehicle(joaat(config.truckModel), vehicleCoords.x, vehicleCoords.y, vehicleCoords.z, vehicleCoords.w, true, true)
-	SetEntityAsMissionEntity(transport)
-	truckBlip = AddBlipForEntity(transport)
-	SetBlipSprite(truckBlip, 67)
-	SetBlipColour(truckBlip, 1)
-	SetBlipFlashes(truckBlip, true)
-	SetBlipRoute(truckBlip,  true)
-	SetBlipRouteColour(truckBlip, config.routeColor)
-	BeginTextCommandSetBlipName('STRING')
-	AddTextComponentString(Lang:t('mission.stockade'))
-	EndTextCommandSetBlipName(truckBlip)
-
-	lib.requestModel(config.guardModel)
-
-	pilot = CreatePed(26, config.guardModel, vehicleCoords.x, vehicleCoords.y, vehicleCoords.z, 268.9422, true, false)
-	navigator = CreatePed(26, config.guardModel, vehicleCoords.x, vehicleCoords.y, vehicleCoords.z, 268.9422, true, false)
-	SetPedIntoVehicle(pilot, transport, -1)
-	SetPedIntoVehicle(navigator, transport, 0)
-	SetPedFleeAttributes(pilot, 0, false)
-	SetPedCombatAttributes(pilot, 46, true)
-	SetPedCombatAbility(pilot, 100)
-	SetPedCombatMovement(pilot, 2)
-	SetPedCombatRange(pilot, 2)
-	SetPedKeepTask(pilot, true)
-	GiveWeaponToPed(pilot, config.driverWeapon,250,false,true)
-	SetPedAsCop(pilot, true)
-
-	SetPedFleeAttributes(navigator, 0, false)
-	SetPedCombatAttributes(navigator, 46, true)
-	SetPedCombatAbility(navigator, 100)
-	SetPedCombatMovement(navigator, 2)
-	SetPedCombatRange(navigator, 2)
-	SetPedKeepTask(navigator, true)
-	TaskEnterVehicle(navigator,transport, -1, 0, 1.0, 1)
-	GiveWeaponToPed(navigator, config.passengerWeapon, 250, false, true)
-	SetPedAsCop(navigator, true)
-
-	TaskVehicleDriveWander(pilot, transport, 80.0, 536871867)
-	TaskVehicleDriveWander(navigator, transport, 80.0, 536871867)
-	missionStarted = true
-	createBombPlantingTarget()
-end)
-
-CreateThread(function()
-	if IsPedDeadOrDying(pilot) and IsPedDeadOrDying(navigator) then
-		guardsDead = true
-		callCops()
-	end
-	Wait(1000)
-end)
-
-function PlantBomb()
-	if not IsVehicleStopped(transport) then
-		exports.qbx_core:Notify(Lang:t('error.truck_ismoving'), 'error')
-		return
-	end
-	if not guardsDead then
-		exports.qbx_core:Notify(Lang:t('error.guards_dead'), 'error')
-		return
-	end
-	if IsEntityInWater(cache.ped) then
-		exports.qbx_core:Notify(Lang:t('info.get_out_water'), 'error')
-		return
-	end
-	exports.ox_target:removeLocalEntity(transport, 'transportPlant')
-	SetCurrentPedWeapon(cache.ped, `WEAPON_UNARMED`,true)
-	Wait(500)
-
-	if lib.progressBar({
-		duration = 5000,
-		label = Lang:t('info.planting_bomb'),
-		useWhileDead = false,
-		canCancel = true,
-		disable = {
-			move = true,
-			car = true,
-			combat = true,
-			mouse = false,
-		},
-		anim = {
-			dict = 'anim@heists@ornate_bank@thermal_charge_heels',
-			clip = 'thermal_charge',
-			flag = 16,
-		},
-		prop = {
-			model = `prop_c4_final_green`,
-			pos = {
-				x = 0.06,
-				y = 0.0,
-				z = 0.06,
-			},
-			rot = {
-				x = 90.0,
-				y = 0.0,
-				z = 0.0,
-			},
-		}
-	}) then
-		exports.ox_target:removeLocalEntity(transport, 'transportPlant')
-		local coords = GetEntityCoords(cache.ped)
-		local prop = CreateObject(`prop_c4_final_green`, coords.x, coords.y, coords.z + 0.2,  true,  true, true)
-		AttachEntityToEntity(prop, transport, GetEntityBoneIndexByName(transport, 'door_pside_r'), -0.7, 0.0, 0.0, 0.0, 0.0, 0.0, true, true, false, true, 1, true)
-		exports.qbx_core:Notify(Lang:t('info.bomb_timer', {TimeToBlow = config.timetoDetonation / 1000}), 'error')
-		Wait(config.timetoDetonation)
-		local transCoords = GetEntityCoords(transport)
-		SetVehicleDoorBroken(transport, 2, false)
-		SetVehicleDoorBroken(transport, 3, false)
-		AddExplosion(transCoords.x,transCoords.y,transCoords.z, 'EXPLOSION_TANKER', 2.0, true, false, 2.0)
-		ApplyForceToEntity(transport, 0, 20.0, 500.0, 0.0, 0.0, 0.0, 0.0, 1, false, true, true, false, true)
-
-		exports.qbx_core:Notify(Lang:t('info.collect'), 'success')
-		--- TODO: seems like these targets should be added for all players instead of just the bomb planter
-		exports.ox_target:addLocalEntity(transport, {
-			name = 'transportTake',
-			label = Lang:t('info.take_money_target'),
-			icon = 'fas fa-sack-dollar',
-			canInteract = function()
-				return QBX.PlayerData.job.type ~= 'leo'
-			end,
-			onSelect = GrabMoney,
-			distance = 3.0,
-		})
-	end
-end
-
-RegisterNetEvent('truckrobbery:CleanUp', function()
-    pickupMoney = 0
-    policeAlert = 0
+local function resetMission()
     guardsDead = false
-    lootable = false
     missionStarted = false
     RemoveBlip(truckBlip)
 	SetBlipRoute(truckBlip, false)
-end)
+end
 
-function GrabMoney()
+lib.callback.register('qbx_truckrobbery:resetMission', resetMission)
+
+local function grabMoney()
 	exports.qbx_core:Notify(Lang:t('success.packing_cash'), 'success')
 
 	if lib.progressBar({
@@ -269,9 +108,162 @@ function GrabMoney()
 			},
 		}
 	}) then
-		exports.ox_target:removeLocalEntity(transport, 'transportTake')
+		exports.ox_target:removeLocalEntity(truck, 'transportTake')
 		SetPedComponentVariation(cache.ped, 5, 45, 0, 2)
-		TriggerServerEvent('truckrobbery:RobberySucess')
-		TriggerEvent('truckrobbery:CleanUp')
+		lib.callback('qbx_truckrobbery:server:giveReward')
+		resetMission()
 	end
 end
+
+local function plantBomb()
+	if not IsVehicleStopped(truck) then
+		exports.qbx_core:Notify(Lang:t('error.truck_ismoving'), 'error')
+		return
+	end
+	if not guardsDead then
+		exports.qbx_core:Notify(Lang:t('error.guards_dead'), 'error')
+		return
+	end
+	if IsEntityInWater(cache.ped) then
+		exports.qbx_core:Notify(Lang:t('info.get_out_water'), 'error')
+		return
+	end
+	exports.ox_target:removeLocalEntity(truck, 'transportPlant')
+	SetCurrentPedWeapon(cache.ped, `WEAPON_UNARMED`,true)
+	Wait(500)
+
+	if lib.progressBar({
+		duration = 5000,
+		label = Lang:t('info.planting_bomb'),
+		useWhileDead = false,
+		canCancel = true,
+		disable = {
+			move = true,
+			car = true,
+			combat = true,
+			mouse = false,
+		},
+		anim = {
+			dict = 'anim@heists@ornate_bank@thermal_charge_heels',
+			clip = 'thermal_charge',
+			flag = 16,
+		},
+		prop = {
+			model = `prop_c4_final_green`,
+			pos = {
+				x = 0.06,
+				y = 0.0,
+				z = 0.06,
+			},
+			rot = {
+				x = 90.0,
+				y = 0.0,
+				z = 0.0,
+			},
+		}
+	}) then
+		exports.ox_target:removeLocalEntity(truck, 'transportPlant')
+		local coords = GetEntityCoords(cache.ped)
+		local prop = CreateObject(`prop_c4_final_green`, coords.x, coords.y, coords.z + 0.2,  true,  true, true)
+		AttachEntityToEntity(prop, truck, GetEntityBoneIndexByName(truck, 'door_pside_r'), -0.7, 0.0, 0.0, 0.0, 0.0, 0.0, true, true, false, true, 1, true)
+		exports.qbx_core:Notify(Lang:t('info.bomb_timer', {TimeToBlow = config.timetoDetonation / 1000}), 'error')
+		Wait(config.timetoDetonation)
+		local transCoords = GetEntityCoords(truck)
+		SetVehicleDoorBroken(truck, 2, false)
+		SetVehicleDoorBroken(truck, 3, false)
+		AddExplosion(transCoords.x,transCoords.y,transCoords.z, 'EXPLOSION_TANKER', 2.0, true, false, 2.0)
+		ApplyForceToEntity(truck, 0, 20.0, 500.0, 0.0, 0.0, 0.0, 0.0, 1, false, true, true, false, true)
+
+		exports.qbx_core:Notify(Lang:t('info.collect'), 'success')
+		--- TODO: seems like these targets should be added for all players instead of just the bomb planter
+		exports.ox_target:addLocalEntity(truck, {
+			name = 'transportTake',
+			label = Lang:t('info.take_money_target'),
+			icon = 'fas fa-sack-dollar',
+			canInteract = function()
+				return QBX.PlayerData.job.type ~= 'leo'
+			end,
+			onSelect = grabMoney,
+			distance = 3.0,
+		})
+	end
+end
+
+local function createBombPlantingTarget()
+	exports.ox_target:addLocalEntity(truck, {
+		name = 'transportPlant',
+		label = Lang:t('info.plant_bomb'),
+		icon = 'fas fa-bomb',
+		canInteract = function()
+			return QBX.PlayerData.job.type ~= 'leo'
+		end,
+		onSelect = plantBomb,
+		distance = 3.0,
+	})
+end
+
+RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function()
+	Wait(2000)
+	config.emailNotification()
+	Wait(3000)
+	ClearPedTasks(dealer)
+	TaskWanderStandard(dealer, 10.0, 10)
+	local vehicleSpawnCoords = config.truckSpawns[math.random(1, #config.truckSpawns)]
+
+	lib.requestModel(config.truckModel)
+
+	ClearAreaOfVehicles(vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 15.0, false, false, false, false, false)
+	truck = CreateVehicle(config.truckModel, vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, vehicleSpawnCoords.w, true, true)
+	SetEntityAsMissionEntity(truck)
+	truckBlip = AddBlipForEntity(truck)
+	SetBlipSprite(truckBlip, 67)
+	SetBlipColour(truckBlip, 1)
+	SetBlipFlashes(truckBlip, true)
+	SetBlipRoute(truckBlip,  true)
+	SetBlipRouteColour(truckBlip, config.routeColor)
+	BeginTextCommandSetBlipName('STRING')
+	AddTextComponentString(Lang:t('mission.stockade'))
+	EndTextCommandSetBlipName(truckBlip)
+
+	lib.requestModel(config.guardModel)
+
+	pilot = CreatePed(26, config.guardModel, vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 268.9422, true, false)
+	navigator = CreatePed(26, config.guardModel, vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 268.9422, true, false)
+
+	CreateThread(function()
+		while true do
+			if IsPedDeadOrDying(pilot) and IsPedDeadOrDying(navigator) then
+				guardsDead = true
+				callCops()
+				return
+			end
+			Wait(1000)
+		end
+	end)
+
+	SetPedIntoVehicle(pilot, truck, -1)
+	SetPedIntoVehicle(navigator, truck, 0)
+	SetPedFleeAttributes(pilot, 0, false)
+	SetPedCombatAttributes(pilot, 46, true)
+	SetPedCombatAbility(pilot, 100)
+	SetPedCombatMovement(pilot, 2)
+	SetPedCombatRange(pilot, 2)
+	SetPedKeepTask(pilot, true)
+	GiveWeaponToPed(pilot, config.driverWeapon,250,false,true)
+	SetPedAsCop(pilot, true)
+
+	SetPedFleeAttributes(navigator, 0, false)
+	SetPedCombatAttributes(navigator, 46, true)
+	SetPedCombatAbility(navigator, 100)
+	SetPedCombatMovement(navigator, 2)
+	SetPedCombatRange(navigator, 2)
+	SetPedKeepTask(navigator, true)
+	TaskEnterVehicle(navigator,truck, -1, 0, 1.0, 1)
+	GiveWeaponToPed(navigator, config.passengerWeapon, 250, false, true)
+	SetPedAsCop(navigator, true)
+
+	TaskVehicleDriveWander(pilot, truck, 80.0, 536871867)
+	TaskVehicleDriveWander(navigator, truck, 80.0, 536871867)
+	missionStarted = true
+	createBombPlantingTarget()
+end)

--- a/config/client.lua
+++ b/config/client.lua
@@ -3,21 +3,21 @@ return {
     dealerCoords = vec3(960.78, -216.25, 76.25), -- place where the NPC stands
 
     truckSpawns = { -- Possible truck spawn locations
-        [1] = vec4(-1215.97, -355.4, 36.9, 208.6),
-        [2] = vec4(-2036.59, -259.78, 23.39, 136.92),
-        [3] = vec4(-1292.28, -807.36, 17.19, 308.12),
-        [4] = vec4(1072.27, -1950.67, 30.62, 144.03),
-        [5] = vec4(1001.3, -55.03, 74.57, 117.98),
-        [6] = vec4(-4.7, -669.71, 32.34, 176.32),
+        vec4(-1215.97, -355.4, 36.9, 208.6),
+        vec4(-2036.59, -259.78, 23.39, 136.92),
+        vec4(-1292.28, -807.36, 17.19, 308.12),
+        vec4(1072.27, -1950.67, 30.62, 144.03),
+        vec4(1001.3, -55.03, 74.57, 117.98),
+        vec4(-4.7, -669.71, 32.34, 176.32),
     },
 
     routeColor = 6, -- Color of the route
 
     driverWeapon = `WEAPON_COMBATPISTOL`, -- Weapon of the driver
     passengerWeapon = `WEAPON_COMBATPISTOL`, -- Weapon of the passenger
-    truckModel = 'Stockade', -- Model of the truck
-    dealerModel = "s_m_y_dealer_01", -- Model of the NPC that gives the mission
-    guardModel = "s_m_m_security_01", -- Model of the guard
+    truckModel = `Stockade`, -- Model of the truck
+    dealerModel = `s_m_y_dealer_01`, -- Model of the NPC that gives the mission
+    guardModel = `s_m_m_security_01`, -- Model of the guard
 
     timetoDetonation = 30 * 1000, -- Time to detonate the bomb, default 30 seconds
 

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,6 +1,4 @@
 return {
-    useTarget = false,
-
     missionMarker = vec3(960.71197509766, -215.51979064941, 76.2552947998), -- Marker to start mission
     dealerCoords = vec3(960.78, -216.25, 76.25), -- place where the NPC stands
 

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -21,7 +21,6 @@ local Translations = {
     },
     info = {
       before_bomb = 'Get rid of the guards before you place the bomb.',
-      detonate_bomb = 'Press [G] to blow up the back door and take the money',
       detonate_bomb_target = 'Plant the Bomb',
       plant_bomb = 'Plant the Bomb',
       planting_bomb = 'Planting the Bomb..',

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -21,7 +21,6 @@ local Translations = {
     },
     info = {
       before_bomb = 'Débarassez vous des gardes avant de placer la bombe.',
-      detonate_bomb = 'Appuyez sur [G] pour exploser la porte arrière et prendre le cash',
       detonate_bomb_target = 'Posez la bombe',
       plant_bomb = 'Poser la bombe',
       planting_bomb = 'Pose la bombe..',

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,33 +1,32 @@
 local config = require 'config.server'
 local isMissionAvailable = true
 
-RegisterServerEvent('truckrobbery:AcceptMission', function()
-	local src = source
-	local player = exports.qbx_core:GetPlayer(src)
+lib.callback.register('qbx_truckrobbery:server:startMission', function(source)
+	local player = exports.qbx_core:GetPlayer(source)
 	if not isMissionAvailable then
-		exports.qbx_core:Notify(src, Lang:t('error.already_active'), 'error')
+		exports.qbx_core:Notify(source, Lang:t('error.already_active'), 'error')
 		return
 	end
 	if player.PlayerData.money.bank < config.activationCost then
-		exports.qbx_core:Notify(src, Lang:t('mission.activation_cost', {cost = config.activationCost}), 'inform')
+		exports.qbx_core:Notify(source, Lang:t('mission.activation_cost', {cost = config.activationCost}), 'inform')
 		return
 	end
 
 	local numCops = exports.qbx_core:GetDutyCountType('leo')
 	if numCops < config.numRequiredPolice then
-		exports.qbx_core:Notify(src, Lang:t('error.active_police', {police = config.numRequiredPolice}), 'error')
+		exports.qbx_core:Notify(source, Lang:t('error.active_police', {police = config.numRequiredPolice}), 'error')
 		return
 	end
 
-	TriggerClientEvent("truckrobbery:StartMission", src)
 	player.Functions.RemoveMoney('bank', config.activationCost, 'armored-truck')
 	isMissionAvailable = false
+	TriggerClientEvent('qbx_truckrobbery:client:missionStarted', source)
 	Wait(config.missionCooldown)
 	isMissionAvailable = true
-	TriggerClientEvent('truckrobbery:CleanUp', -1)
+	lib.callback('qbx_truckrobbery:client:resetMission', -1)
 end)
 
-RegisterNetEvent('truckrobbery:server:callCops', function(coords)
+lib.callback.register('qbx_truckrobbery:server:callCops', function(_, coords)
 	local msg = Lang:t("info.alert_desc")
     local alertData = {
         title = Lang:t("info.alerttitle"),
@@ -41,20 +40,19 @@ RegisterNetEvent('truckrobbery:server:callCops', function(coords)
 	local numCops, copSrcs = exports.qbx_core:GetDutyCountType('leo')
 	for i = 1, numCops do
 		local copSrc = copSrcs[i]
-		TriggerClientEvent("truckrobbery:client:robberyCall", copSrc, msg, coords)
+		lib.callback('qbx_truckrobbery:client:notifyCop', copSrc, nil, msg, coords)
 		TriggerClientEvent("qb-phone:client:addPoliceAlert", copSrc, alertData)
 	end
 end)
 
-RegisterServerEvent('truckrobbery:RobberySucess', function()
-	local src = source
-	local player = exports.qbx_core:GetPlayer(src)
+lib.callback.register('qbx_truckrobbery:server:giveReward', function(source)
+	local player = exports.qbx_core:GetPlayer(source)
 	local bags = math.random(1,3)
 	local info = {
 		worth = math.random(config.minReward, config.maxReward)
 	}
 	player.Functions.AddItem('markedbills', bags, false, info)
-	exports.qbx_core:Notify(src, Lang:t('success.took_bags', {bags = bags}), 'success')
+	exports.qbx_core:Notify(source, Lang:t('success.took_bags', {bags = bags}), 'success')
 	if math.random() <= 0.05 then
 		player.Functions.AddItem('security_card_01', 1)
 	end


### PR DESCRIPTION
Deconstruction and rebuilding parts to provide a similar player experience with much more simplified code. Wanting to start from something simple and then add more complication from a strong base.

- Removing markers (they are a bit too gamey)
- Forcing ox_target as only means of interaction (there are some complications involving doing distance checks for interaction, best to simplify code for now and add other interaction in later as a feature if someone is interested in PRing it, but I think forcing ox_target is fine).
- Removing some notifications to guide player through the heist (while this isn't bad, it again requires weird thread distance checking stuff, so removing it for now to simplify and it can be added back later)
- Added some TODOs. Currently it seems only the mission starter can interact with the mission. A nice feature would be allowing any non-cop player to interact with the mission, but then we also need server side locks/checks to ensure multiple players can't be doing the same action at the same time
- Renaming events and changing most of them to callbacks