### PR TITLE
fix(client): alert police and detToTime in seconds

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -149,9 +149,10 @@ local function plantBomb()
 		exports.ox_target:removeEntity(netId, 'transportPlant')
 		local coords = GetEntityCoords(cache.ped)
 		local prop = CreateObject(`prop_c4_final_green`, coords.x, coords.y, coords.z + 0.2,  true,  true, true)
+		local detTime = config.timeToDetonation * 1000 / 60
 		AttachEntityToEntity(prop, truck, GetEntityBoneIndexByName(truck, 'door_pside_r'), -0.7, 0.0, 0.0, 0.0, 0.0, 0.0, true, true, false, true, 1, true)
-		exports.qbx_core:Notify(locale('info.bomb_timer', config.timetoDetonation / 1000), 'inform')
-		Wait(config.timetoDetonation)
+		exports.qbx_core:Notify(locale('info.bomb_timer', detTime), 'inform')
+		Wait(detTime)
 		local transCoords = GetEntityCoords(truck)
 		SetVehicleDoorBroken(truck, 2, false)
 		SetVehicleDoorBroken(truck, 3, false)
@@ -222,7 +223,7 @@ RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function()
 
 	CreateThread(function()
 		while true do
-			if IsPedDeadOrDying(pilot) and IsPedDeadOrDying(navigator) then
+			if IsPedDeadOrDying(pilot) or IsPedDeadOrDying(navigator) then
 				guardsDead = true
 				alertPolice()
 				return

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,5 +1,4 @@
 return {
-    missionMarker = vec3(960.71197509766, -215.51979064941, 76.2552947998), -- Marker to start mission
     dealerCoords = vec4(960.78, -216.25, 76.25, 1.8), -- place where the NPC stands
 
     truckSpawns = { -- Possible truck spawn locations
@@ -19,7 +18,7 @@ return {
     dealerModel = `s_m_y_dealer_01`, -- Model of the NPC that gives the mission
     guardModel = `s_m_m_security_01`, -- Model of the guard
 
-    timetoDetonation = 30 * 1000, -- Time to detonate the bomb, default 30 seconds
+    timeToDetonation = 30, -- Time in seconds till bomb detonation after placement
 
     -- Used for mission notification
     emailNotification = function()


### PR DESCRIPTION
## Description

- Alerts the police if either the pilot or navigator is dead or dying instead of requiring both to be dead or dying
- Changes config to time in seconds and doing the math in client/main.lua
- Removes an unused config option

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
