### PR TITLE
fix(client/main): detonation time being sped up 60x

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -148,7 +148,7 @@ local function plantBomb()
 		exports.ox_target:removeEntity(netId, 'transportPlant')
 		local coords = GetEntityCoords(cache.ped)
 		local prop = CreateObject(`prop_c4_final_green`, coords.x, coords.y, coords.z + 0.2,  true,  true, true)
-		local detTime = config.timeToDetonation * 1000 / 60
+		local detTime = config.timeToDetonation * 1000
 		AttachEntityToEntity(prop, truck, GetEntityBoneIndexByName(truck, 'door_pside_r'), -0.7, 0.0, 0.0, 0.0, 0.0, 0.0, true, true, false, true, 1, true)
 		exports.qbx_core:Notify(locale('info.bomb_timer', detTime), 'inform')
 		Wait(detTime)


### PR DESCRIPTION
Bomb detonation timer no longer sped up by 60x what it is supposed to be