### PR TITLE
feat(server): loot table

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -15,7 +15,6 @@ return {
             item = 'black_money',
             minAmount = 250,
             maxAmount = 450,
-            probability = 1.0,
         },
         {
             item = 'security_card_01',

--- a/config/server.lua
+++ b/config/server.lua
@@ -3,6 +3,23 @@ return {
     activationCost = 500, -- How much is the activation of the mission (clean from the bank)
     missionCooldown = 2700 * 1000, -- Timer every how many missions you can do, default is 600 seconds
 
-    minReward = 250, -- How much minimum you can get from a robbery
-    maxReward = 450, -- How much maximum you can get from a robbery
+    ---@class Reward
+    ---@field item string
+    ---@field minAmount? integer default 1
+    ---@field maxAmount? integer default 1
+    ---@field probability? number 0.0 to 1.0, the independent probability of the reward being present. Defaults to 1.0
+
+    ---@type Reward[]
+    rewards = {
+        {
+            item = 'black_money',
+            minAmount = 250,
+            maxAmount = 450,
+            probability = 1.0,
+        },
+        {
+            item = 'security_card_01',
+            probability = 0.05
+        }
+    },
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -56,10 +56,12 @@ lib.callback.register('qbx_truckrobbery:server:plantedBomb', function(source)
 end)
 
 lib.callback.register('qbx_truckrobbery:server:giveReward', function(source)
-	local reward = math.random(config.minReward, config.maxReward)
-	exports.ox_inventory:AddItem(source, 'black_money', reward)
+    for i = 1, #config.rewards do
+        local reward = config.rewards[i]
+        if not reward.probability or math.random() <= reward.probability then
+            local amount = math.random(reward.minAmount or 1, reward.maxAmount or 1)
+            exports.ox_inventory:AddItem(source, reward.item, amount)
+        end
+    end
 	exports.qbx_core:Notify(source, locale('success.looted'), 'success')
-	if math.random() <= 0.05 then
-		exports.ox_inventory:AddItem(source, 'security_card_01', 1)
-	end
 end)


### PR DESCRIPTION
Replaces hardcoded black_money reward with a loot table for more customization of rewards. A probability check is taken for each item in the back of the truck.