### PR TITLE
feat: server side statebags

### DIFF
--- a/config/client.lua
+++ b/config/client.lua
@@ -18,8 +18,6 @@ return {
     dealerModel = `s_m_y_dealer_01`, -- Model of the NPC that gives the mission
     guardModel = `s_m_m_security_01`, -- Model of the guard
 
-    timeToDetonation = 30, -- Time in seconds till bomb detonation after placement
-
     -- Used for mission notification
     emailNotification = function()
         TriggerServerEvent('qb-phone:server:sendNewMail', {

--- a/config/server.lua
+++ b/config/server.lua
@@ -21,4 +21,5 @@ return {
             probability = 0.05
         }
     },
+    timeToDetonation = 30, -- Time in seconds till bomb detonation after placement
 }


### PR DESCRIPTION
- set statebags only on the server to prevent issue where player triggering statebag gets the handler triggered twice
- move some things server side like parts of the explosion, timer, etc.
- Use qbx statebag entity handler instead of native
- Added beeping sound to the c4 prop
- Some cleanup of converting tables to vec3