### PR TITLE
feat: truck/guard overhaul

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -117,7 +117,7 @@ RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function()
 		coords = vehicleSpawnCoords,
 		distance = 300,
 	})
-	 
+
 	function point:onEnter()
 		local netId = lib.callback.await('qbx_truckrobbery:server:spawnVehicle', false, vehicleSpawnCoords)
 		lib.waitFor(function()
@@ -125,11 +125,11 @@ RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function()
 				truck = NetToVeh(netId)
 				return truck
 			end
-    	end, locale('no_truck_spawned'))
+		end, locale('no_truck_spawned'))
 
 		exports.qbx_core:Notify(locale('info.truck_spotted'), 'inform')
 		RemoveBlip(area)
-		
+
 		truckBlip = AddBlipForEntity(truck)
 		SetBlipSprite(truckBlip, 67)
 		SetBlipColour(truckBlip, 1)

--- a/client/main.lua
+++ b/client/main.lua
@@ -4,7 +4,7 @@ local truckBlip
 local truck
 local area
 local missionStarted = false
-local dealer, pilot, navigator
+local dealer
 local c4Prop
 
 AddEventHandler('onResourceStop', function(resource)
@@ -13,8 +13,8 @@ AddEventHandler('onResourceStop', function(resource)
 	DeletePed(dealer)
 end)
 
-local function alertPolice()
-	lib.callback('qbx_truckrobbery:server:callCops', false, nil, GetEntityCoords(truck))
+local function alertPolice(coords)
+	lib.callback('qbx_truckrobbery:server:callCops', false, nil, coords)
 	PlaySoundFrontend(-1, 'Mission_Pass_Notify', 'DLC_HEISTS_GENERAL_FRONTEND_SOUNDS', false)
 end
 
@@ -103,86 +103,49 @@ end
 
 RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function()
 	exports.qbx_core:Notify('Go to the designated location to find the bank truck')
-	Wait(2000)
 	config.emailNotification()
-	Wait(3000)
 	local vehicleSpawnCoords = config.truckSpawns[math.random(1, #config.truckSpawns)]
 
-	lib.requestModel(config.truckModel)
-
-	area = AddBlipForRadius(vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 450.0)
+	area = AddBlipForRadius(vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 300.0)
 	SetBlipHighDetail(area, true)
 	SetBlipAlpha(area, 90)
 	SetBlipRoute(area, true)
 	SetBlipRouteColour(area, config.routeColor)
 	SetBlipColour(area, 1)
 
-	ClearAreaOfVehicles(vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 15.0, false, false, false, false, false)
-	local netId = lib.callback.await('qbx_truckrobbery:server:spawnVehicle', false, config.truckModel, vehicleSpawnCoords)
-	lib.waitFor(function()
-        if NetworkDoesEntityExistWithNetworkId(netId) then
-			truck = NetToVeh(netId)
-            return truck
-        end
-    end, locale('no_truck_spawned'))
-
-	exports.qbx_core:Notify(locale('info.truck_spotted'), 'inform')
-
-	RemoveBlip(area)
-
-	truckBlip = AddBlipForEntity(truck)
-	SetBlipSprite(truckBlip, 67)
-	SetBlipColour(truckBlip, 1)
-	SetBlipFlashes(truckBlip, true)
-	SetBlipRoute(truckBlip, true)
-	SetBlipRouteColour(truckBlip, config.routeColor)
-	BeginTextCommandSetBlipName('STRING')
-	AddTextComponentString('Armored Truck')
-	EndTextCommandSetBlipName(truckBlip)
-	lib.requestModel(config.guardModel, 5000)
-
-	pilot = CreatePed(26, config.guardModel, vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 268.9422, true, false)
-	navigator = CreatePed(26, config.guardModel, vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 268.9422, true, false)
-
-	CreateThread(function()
-		while true do
-			if IsPedDeadOrDying(pilot) or IsPedDeadOrDying(navigator) then
-				TriggerServerEvent('qbx_truckrobbery:server:guardKilled')
-				alertPolice()
-				return
+	local point = lib.points.new({
+		coords = vehicleSpawnCoords,
+		distance = 300,
+	})
+	 
+	function point:onEnter()
+		local netId = lib.callback.await('qbx_truckrobbery:server:spawnVehicle', false, vehicleSpawnCoords)
+		lib.waitFor(function()
+			if NetworkDoesEntityExistWithNetworkId(netId) then
+				truck = NetToVeh(netId)
+				return truck
 			end
-			Wait(1000)
-		end
-	end)
+    	end, locale('no_truck_spawned'))
 
-	SetPedIntoVehicle(pilot, truck, -1)
-	SetPedIntoVehicle(navigator, truck, 0)
-	SetPedFleeAttributes(pilot, 0, false)
-	SetPedCombatAttributes(pilot, 46, true)
-	SetPedCombatAbility(pilot, 100)
-	SetPedCombatMovement(pilot, 2)
-	SetPedCombatRange(pilot, 2)
-	SetPedKeepTask(pilot, true)
-	GiveWeaponToPed(pilot, config.driverWeapon, 250, false, true)
-	SetPedAsCop(pilot, true)
-
-	SetPedFleeAttributes(navigator, 0, false)
-	SetPedCombatAttributes(navigator, 46, true)
-	SetPedCombatAbility(navigator, 100)
-	SetPedCombatMovement(navigator, 2)
-	SetPedCombatRange(navigator, 2)
-	SetPedKeepTask(navigator, true)
-	TaskEnterVehicle(navigator,truck, -1, 0, 1.0, 1)
-	GiveWeaponToPed(navigator, config.passengerWeapon, 250, false, true)
-	SetPedAsCop(navigator, true)
-
-	TaskVehicleDriveWander(pilot, truck, 80.0, 536871867)
-	TaskVehicleDriveWander(navigator, truck, 80.0, 536871867)
+		exports.qbx_core:Notify(locale('info.truck_spotted'), 'inform')
+		RemoveBlip(area)
+		
+		truckBlip = AddBlipForEntity(truck)
+		SetBlipSprite(truckBlip, 67)
+		SetBlipColour(truckBlip, 1)
+		SetBlipFlashes(truckBlip, true)
+		SetBlipRoute(truckBlip, true)
+		SetBlipRouteColour(truckBlip, config.routeColor)
+		BeginTextCommandSetBlipName('STRING')
+		AddTextComponentString('Armored Truck')
+		EndTextCommandSetBlipName(truckBlip)
+		alertPolice(GetEntityCoords(vehicleSpawnCoords))
+		point:remove()
+	end
 	missionStarted = true
 end)
 
 qbx.entityStateHandler('truckstate', function(entity, _, value)
-	lib.print.info("truckstate changed", value)
 	if entity == 0 then return end
     truck = entity
     if value == TruckState.PLANTABLE then
@@ -235,6 +198,24 @@ qbx.entityStateHandler('truckstate', function(entity, _, value)
     elseif value == TruckState.LOOTED then
 		exports.ox_target:removeLocalEntity(truck, 'transportTake')
     end
+end)
+
+qbx.entityStateHandler('qbx_truckrobbery:initGuard', function(entity, _, value)
+	if not value then return end
+	while GetVehiclePedIsIn(entity, false) == 0 do
+		Wait(100)
+	end
+	SetPedFleeAttributes(entity, 0, false)
+	SetPedCombatAttributes(entity, 46, true)
+	SetPedCombatAbility(entity, 100)
+	SetPedCombatMovement(entity, 2)
+	SetPedCombatRange(entity, 2)
+	SetPedKeepTask(entity, true)
+	SetPedAsCop(entity, true)
+	SetPedHighlyPerceptive(entity, true)
+	TaskVehicleDriveWander(entity, truck, 60.0, 524860)
+
+	Entity(entity).state:set('qbx_truckrobbery:initGuard', false, true)
 end)
 
 lib.requestModel(config.dealerModel, 5000)

--- a/config/client.lua
+++ b/config/client.lua
@@ -11,12 +11,7 @@ return {
     },
 
     routeColor = 6, -- Color of the route
-
-    driverWeapon = `WEAPON_COMBATPISTOL`, -- Weapon of the driver
-    passengerWeapon = `WEAPON_COMBATPISTOL`, -- Weapon of the passenger
-    truckModel = `Stockade`, -- Model of the truck
     dealerModel = `s_m_y_dealer_01`, -- Model of the NPC that gives the mission
-    guardModel = `s_m_m_security_01`, -- Model of the guard
 
     -- Used for mission notification
     emailNotification = function()

--- a/config/server.lua
+++ b/config/server.lua
@@ -22,4 +22,8 @@ return {
         }
     },
     timeToDetonation = 30, -- Time in seconds till bomb detonation after placement
+    driverWeapon = `WEAPON_COMBATPISTOL`, -- Weapon of the driver
+    passengerWeapon = `WEAPON_COMBATPISTOL`, -- Weapon of the passenger
+    truckModel = `Stockade`, -- Model of the truck
+    guardModel = `s_m_m_security_01`, -- Model of the guard
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -2,12 +2,12 @@
     "error": {
         "activation_cost": "You need $%s in order to accept this mission...",
         "get_out_water": "You must get out of the water before planting the bomb...",
-        "guards_dead": "All the guards must be dead in order to place the bomb...",
         "truck_moving": "You can't rob a vehicle while it's moving...",
         "missing_bomb": "It appears you don't have a bomb...",
         "active_police": "You need at least %s police in order to activate this mission...",
         "already_active": "Someone is already carrying out a mission...",
-        "no_truck_spawned": "It looks like there is an issue spawning the armored truck..."
+        "no_truck_spawned": "It looks like there is an issue spawning the armored truck...",
+        "truck_escaped": "The truck has escaped! Mission Failed."
     },
     "success": {
         "looted": "You've successfully looted the truck"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2,7 +2,6 @@
     "error": {
         "activation_cost": "Vous avez besoin de $ %{cost} en banque pour accepter la mission...",
         "get_out_water": "Sortez de l'eau...",
-        "guards_dead": "Les gardes doivent être morts pour placer la bombe...",
         "truck_moving": "Vous ne pouvez pas braquer un camion en mouvement...",
         "missing_bomb": "It appears you don't have a bomb...",
         "active_police": "Il faut au moins %s policiers pour activer la mission...",

--- a/shared/types.lua
+++ b/shared/types.lua
@@ -1,7 +1,5 @@
 ---@enum TruckState
 TruckState = {
-    DEFAULT = 'default',
-    MOVING = 'moving',
     PLANTABLE = 'plantable',
     PLANTED = 'planted',
     LOOTABLE = 'lootable',


### PR DESCRIPTION
## Description

- remove requirement to kill guards to plant bomb. Instead, police are called when the mission owner comes in range. This also means the truck spawns in plantable state. Removed DEFAULT/MOVING states since they ended up being unused
- truck only spawns now when mission owner is near
- removed delays to send email and draw circle on the map
- using more statebags to protect against edge cases where the owner of the entities is different than the mission owner
- Made the truck drive more erratically to make things more fun. (doesn't stop at red lights, or for objects/players etc)
- If no player is within scope of the truck, the mission fails and the truck is de-spawned
- truck doors start locked

Future plans:
- add a few extra guards in the back when blownup for extra challenge
- Change the police alert to only occur when a player is extremely close to the truck. This will let players stalk the truck from a distance without police being alerted

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
