### PR TITLE
feat: guards in the back

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -158,7 +158,7 @@ qbx.entityStateHandler('truckstate', function(entity, _, value)
             end,
 			bones = {
 				'seat_dside_r',
-        		'seat_pside_r',
+				'seat_pside_r',
 			},
             onSelect = plantBomb,
             distance = 3.0,
@@ -198,7 +198,7 @@ qbx.entityStateHandler('truckstate', function(entity, _, value)
 			end,
 			bones = {
 				'seat_dside_r',
-        		'seat_pside_r',
+				'seat_pside_r',
 			},
 			onSelect = lootTruck,
 			distance = 3.0,

--- a/client/main.lua
+++ b/client/main.lua
@@ -156,6 +156,10 @@ qbx.entityStateHandler('truckstate', function(entity, _, value)
             canInteract = function()
                 return QBX.PlayerData.job.type ~= 'leo'
             end,
+			bones = {
+				'seat_dside_r',
+        		'seat_pside_r',
+			},
             onSelect = plantBomb,
             distance = 3.0,
         })
@@ -192,6 +196,10 @@ qbx.entityStateHandler('truckstate', function(entity, _, value)
 			canInteract = function()
 				return QBX.PlayerData.job.type ~= 'leo'
 			end,
+			bones = {
+				'seat_dside_r',
+        		'seat_pside_r',
+			},
 			onSelect = lootTruck,
 			distance = 3.0,
 		})
@@ -212,9 +220,9 @@ qbx.entityStateHandler('qbx_truckrobbery:initGuard', function(entity, _, value)
 	SetPedCombatRange(entity, 2)
 	SetPedKeepTask(entity, true)
 	SetPedAsCop(entity, true)
-	SetPedHighlyPerceptive(entity, true)
+	SetPedCanSwitchWeapon(entity, true)
+	SetPedAccuracy(entity, config.guardAccuracy)
 	TaskVehicleDriveWander(entity, truck, 60.0, 524860)
-
 	Entity(entity).state:set('qbx_truckrobbery:initGuard', false, true)
 end)
 

--- a/config/client.lua
+++ b/config/client.lua
@@ -21,4 +21,5 @@ return {
             message = locale('mission.message'),
         })
     end,
+    guardAccuracy = 50,
 }

--- a/config/server.lua
+++ b/config/server.lua
@@ -23,7 +23,8 @@ return {
     },
     timeToDetonation = 30, -- Time in seconds till bomb detonation after placement
     driverWeapon = `WEAPON_COMBATPISTOL`, -- Weapon of the driver
-    passengerWeapon = `WEAPON_COMBATPISTOL`, -- Weapon of the passenger
+    passengerWeapon = `WEAPON_COMBATSHOTGUN`, -- Weapon of the passenger
+    backPassengerWeapon = `WEAPON_TACTICALRIFLE`,
     truckModel = `Stockade`, -- Model of the truck
     guardModel = `s_m_m_security_01`, -- Model of the guard
 }


### PR DESCRIPTION
## Description

- guard accuracy config option
- added two additional guards in the rear
- config options for different guards to have different weapons
- sneaking in a bone filter to only be able to target the rear of the truck for planting c4 and looting

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
