### PR TITLE
feat: polishing

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -3,7 +3,6 @@ local sharedConfig = require 'config.shared'
 local truckBlip
 local truck
 local area
-local missionStarted = false
 local dealer
 local c4Prop
 
@@ -19,7 +18,6 @@ local function alertPolice(coords)
 end
 
 local function resetMission()
-    missionStarted = false
     RemoveBlip(truckBlip)
     RemoveBlip(area)
 end
@@ -71,7 +69,7 @@ local function plantBomb()
 		exports.qbx_core:Notify(locale('error.missing_bomb'), 'error')
 		return
 	end
-	SetCurrentPedWeapon(cache.ped, `WEAPON_UNARMED`, true)
+    TriggerClientEvent('ox_inventory:disarm', cache.playerId)
 	Wait(500)
 
 	if lib.progressBar({
@@ -101,10 +99,9 @@ local function plantBomb()
 	end
 end
 
-RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function()
+RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function(vehicleSpawnCoords)
 	exports.qbx_core:Notify('Go to the designated location to find the bank truck')
 	config.emailNotification()
-	local vehicleSpawnCoords = config.truckSpawns[math.random(1, #config.truckSpawns)]
 
 	area = AddBlipForRadius(vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 300.0)
 	SetBlipHighDetail(area, true)
@@ -139,10 +136,9 @@ RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function()
 		BeginTextCommandSetBlipName('STRING')
 		AddTextComponentString('Armored Truck')
 		EndTextCommandSetBlipName(truckBlip)
-		alertPolice(GetEntityCoords(vehicleSpawnCoords))
+		alertPolice(vehicleSpawnCoords)
 		point:remove()
 	end
-	missionStarted = true
 end)
 
 qbx.entityStateHandler('truckstate', function(entity, _, value)
@@ -213,6 +209,8 @@ qbx.entityStateHandler('qbx_truckrobbery:initGuard', function(entity, _, value)
 	while GetVehiclePedIsIn(entity, false) == 0 do
 		Wait(100)
 	end
+    if NetworkGetEntityOwner(entity) ~= cache.playerId then return end
+
 	SetPedFleeAttributes(entity, 0, false)
 	SetPedCombatAttributes(entity, 46, true)
 	SetPedCombatAbility(entity, 100)
@@ -239,7 +237,7 @@ exports.ox_target:addLocalEntity(dealer, {
     label = locale('mission.ask_for_mission'),
     icon = 'fas fa-circle-check',
     canInteract = function()
-        return not missionStarted and QBX.PlayerData.job.type ~= 'leo'
+        return QBX.PlayerData.job.type ~= 'leo'
     end,
     onSelect = function()
         lib.callback('qbx_truckrobbery:server:startMission')

--- a/client/main.lua
+++ b/client/main.lua
@@ -69,7 +69,7 @@ local function plantBomb()
 		exports.qbx_core:Notify(locale('error.missing_bomb'), 'error')
 		return
 	end
-    TriggerClientEvent('ox_inventory:disarm', cache.playerId)
+    TriggerEvent('ox_inventory:disarm', cache.playerId)
 	Wait(500)
 
 	if lib.progressBar({

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,15 +1,5 @@
 return {
     dealerCoords = vec4(960.78, -216.25, 75.25, 1.8), -- place where the NPC stands
-
-    truckSpawns = { -- Possible truck spawn locations
-        vec4(-1201.8, -370.18, 37.29, 27.79),
-        vec4(-2036.59, -259.78, 23.39, 136.92),
-        vec4(-1292.28, -807.36, 17.19, 308.12),
-        vec4(1072.27, -1950.67, 30.62, 144.03),
-        vec4(1001.3, -55.03, 74.57, 117.98),
-        vec4(-4.7, -669.71, 32.34, 176.32),
-    },
-
     routeColor = 6, -- Color of the route
     dealerModel = `s_m_y_dealer_01`, -- Model of the NPC that gives the mission
 

--- a/config/server.lua
+++ b/config/server.lua
@@ -27,4 +27,32 @@ return {
     backPassengerWeapon = `WEAPON_TACTICALRIFLE`,
     truckModel = `Stockade`, -- Model of the truck
     guardModel = `s_m_m_security_01`, -- Model of the guard
+
+    truckSpawns = { -- Possible truck spawn locations
+        vec4(-1201.8, -370.18, 37.29, 27.79),
+        vec4(-2036.59, -259.78, 23.39, 136.92),
+        vec4(-1292.28, -807.36, 17.19, 308.12),
+        vec4(1072.27, -1950.67, 30.62, 144.03),
+        vec4(1001.3, -55.03, 74.57, 117.98),
+        vec4(-4.7, -669.71, 32.34, 176.32),
+    },
+
+    alertPolice = function(coords)
+        local msg = locale("info.alert_desc")
+        local alertData = {
+            title = locale('info.alert_title'),
+            coords = {
+                x = coords.x,
+                y = coords.y,
+                z = coords.z
+            },
+            description = msg
+        }
+        local numCops, copSrcs = exports.qbx_core:GetDutyCountType('leo')
+        for i = 1, numCops do
+            local copSrc = copSrcs[i]
+            TriggerClientEvent('police:client:policeAlert', copSrc, coords, msg)
+            TriggerClientEvent('qb-phone:client:addPoliceAlert', copSrc, alertData)
+        end
+    end
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,3 +1,3 @@
 return {
-    bombItem = 'meth'
+    bombItem = 'weapon_stickybomb'
 }


### PR DESCRIPTION
- Removed missionStarted tracking on the client to now show the ox_target mission giver all the timer. It will still fail if the mission is already started enforced by the server, but I think it's better that players can find it all the time, rather than only when available
- fix disarming player when planting the bomb
- defaulting bomb item back to sticky bomb
- moved vehicle spawn coords to the server config as an anti-dumping measure
- fixed alert police coords not being passed correctly and moved the function as server config so that people can override it to suit their dispatch script
- filtering out non-owners from attempting to init guard attributes
- once the truck is looted, leaving the area no longer displays a notification that it has escaped