### PR TITLE
fix: guards sometimes not spawning

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -110,7 +110,7 @@ RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function(vehicleSpawn
 	exports.qbx_core:Notify('Go to the designated location to find the bank truck')
 	config.emailNotification()
 
-	area = AddBlipForRadius(vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 300.0)
+	area = AddBlipForRadius(vehicleSpawnCoords.x, vehicleSpawnCoords.y, vehicleSpawnCoords.z, 250.0)
 	SetBlipHighDetail(area, true)
 	SetBlipAlpha(area, 90)
 	SetBlipRoute(area, true)

--- a/client/main.lua
+++ b/client/main.lua
@@ -119,7 +119,7 @@ RegisterNetEvent('qbx_truckrobbery:client:missionStarted', function(vehicleSpawn
 
 	local point = lib.points.new({
 		coords = vehicleSpawnCoords,
-		distance = 300,
+		distance = 250,
 	})
 
 	function point:onEnter()


### PR DESCRIPTION
Was noticing that once getting 8+ players on a server, the guards would often fail to spawn in the truck. Reducing this distance seems to have fixed that. Not sure why. Wondering if the vehicle spawn distance for one sync is 300?