### PR TITLE
fix(client): lib.progressActive

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -55,7 +55,7 @@ local function lootTruck()
         looting = false
     end)
     while looting do
-        if #(GetEntityCoords(cache.ped) - GetEntityCoords(truck)) > 3 then
+        if #(GetEntityCoords(cache.ped) - GetEntityCoords(truck)) > 3 and lib.progressActive() then
             lib.cancelProgress()
         end
         Wait(1000)


### PR DESCRIPTION
Check if progress bar is active to avoid potential errors. (untested but it seems pretty logical)