### PR TITLE
fix(client): increase distance check to 6

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -55,7 +55,7 @@ local function lootTruck()
         looting = false
     end)
     while looting do
-        if #(GetEntityCoords(cache.ped) - GetEntityCoords(truck)) > 3 and lib.progressActive() then
+        if #(GetEntityCoords(cache.ped) - GetEntityCoords(truck)) > 6 and lib.progressActive() then
             lib.cancelProgress()
         end
         Wait(1000)


### PR DESCRIPTION
## Description

Fixes issue with `ped - truck` distance > 3 preventing successful loot

https://discord.com/channels/1012753553418354748/1219696411004764160

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
