### PR TITLE
feat: Notify player about detonation time

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -90,7 +90,7 @@ end)
 lib.callback.register('qbx_truckrobbery:server:plantedBomb', function(source)
 	if Entity(truck).state.truckstate ~= TruckState.PLANTABLE then return end
 	if not exports.ox_inventory:RemoveItem(source, sharedConfig.bombItem, 1) then return end
-    exports.qbx_core:Notify(source, locale('info.bomb_timer', config.timeToDetonation * 1000), 'inform')
+    exports.qbx_core:Notify(source, locale('info.bomb_timer', config.timeToDetonation))
     Entity(truck).state:set('truckstate', TruckState.PLANTED, true)
 	SetTimeout(config.timeToDetonation * 1000, function()
 		SetVehicleDoorBroken(truck, 2, false)

--- a/server/main.lua
+++ b/server/main.lua
@@ -90,7 +90,8 @@ end)
 lib.callback.register('qbx_truckrobbery:server:plantedBomb', function(source)
 	if Entity(truck).state.truckstate ~= TruckState.PLANTABLE then return end
 	if not exports.ox_inventory:RemoveItem(source, sharedConfig.bombItem, 1) then return end
-	Entity(truck).state:set('truckstate', TruckState.PLANTED, true)
+    exports.qbx_core:Notify(source, locale('info.bomb_timer', config.timeToDetonation * 1000), 'inform')
+    Entity(truck).state:set('truckstate', TruckState.PLANTED, true)
 	SetTimeout(config.timeToDetonation * 1000, function()
 		SetVehicleDoorBroken(truck, 2, false)
 		SetVehicleDoorBroken(truck, 3, false)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Brought info.bomb_timer back to use, was probably accidentally forgotten

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.