### PR TITLE
Fix wrong net event source param

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -88,7 +88,8 @@ lib.callback.register('qbx_truckrobbery:server:spawnVehicle', function(source, c
 	return netId
 end)
 
-RegisterNetEvent('qbx_truckrobbery:server:plantedBomb', function(source)
+RegisterNetEvent('qbx_truckrobbery:server:plantedBomb', function()
+    local source = source
 	if Entity(truck).state.truckstate ~= TruckState.PLANTABLE then return end
 	if not exports.ox_inventory:RemoveItem(source, sharedConfig.bombItem, 1) then return end
     exports.qbx_core:Notify(source, locale('info.bomb_timer', config.timeToDetonation))


### PR DESCRIPTION
This event was not loading correctly as the source parameter was in the argument list.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My pull request fits the contribution guidelines & code conventions.
